### PR TITLE
Add tests for abstract attribute

### DIFF
--- a/lib/lobster/abstract_attribute.rb
+++ b/lib/lobster/abstract_attribute.rb
@@ -1,6 +1,8 @@
 # Custom class attributes.
 class Class
 
+  private
+
   # Defines an abstract method.
   # The method will throw a {NotImplementedError} when invoked.
   # This requires that the method be defined in a sub-class.

--- a/spec/lib/lobster/abstract_attribute_spec.rb
+++ b/spec/lib/lobster/abstract_attribute_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../../spec_helper'
+
+RSpec.describe 'abstract' do
+  subject(:klass) do
+    klass = Class.new
+    klass.send(:abstract, :abstract_method)
+    klass
+  end
+
+  it 'is private' do
+    expect(Class.private_methods).to include(:abstract)
+  end
+
+  it 'creates a method' do
+    expect(klass.public_instance_methods).to include(:abstract_method)
+  end
+
+  describe 'the method' do
+    let(:instance) { klass.new }
+    subject(:call) { instance.abstract_method }
+
+    it 'raises NotImplementError' do
+      expect { call }.to raise_error NotImplementedError
+    end
+
+    describe 'the error' do
+      subject do
+        begin
+          call
+          nil
+        rescue Object => ex
+          ex
+        end.to_s
+      end
+
+      it 'says the method is abstract' do
+        is_expected.to include('abstract')
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Testing revealed that 'abstract' was public and would allow outside sources to create abstract methods.
